### PR TITLE
Removes polling logic.

### DIFF
--- a/src/components/sign-in.tsx
+++ b/src/components/sign-in.tsx
@@ -65,6 +65,7 @@ export function SignIn({ clientId, onError, onSuccess, scopes }: SignInProps) {
   };
 
   const { code, url } = useAuthUrl({ clientId, onError: doError, scopes });
+  const localUrl = url?.replace('https://fractal.is', 'http://localhost:3000');
 
   const signIn = async () => {
     const width = 400;
@@ -72,7 +73,7 @@ export function SignIn({ clientId, onError, onSuccess, scopes }: SignInProps) {
     const left = window.screenX + (window.innerWidth - width) / 2;
     const top = window.screenY + (window.innerHeight - height) / 2;
     const popup = window.open(
-      url,
+      localUrl,
       'fractal:approval:popup',
       `popup,left=${left},top=${top},width=${width},height=${height},resizable,scrollbars=yes,status=1`,
     );
@@ -81,7 +82,7 @@ export function SignIn({ clientId, onError, onSuccess, scopes }: SignInProps) {
         if (e.data.event === Events.HANDSHAKE) {
           popup.window.postMessage(
             {
-              event: Events.HANDSHAKE,
+              event: Events.HANDSHAKE_ACK,
               payload: {
                 clientId,
                 code,

--- a/src/components/sign-in.tsx
+++ b/src/components/sign-in.tsx
@@ -65,7 +65,6 @@ export function SignIn({ clientId, onError, onSuccess, scopes }: SignInProps) {
   };
 
   const { code, url } = useAuthUrl({ clientId, onError: doError, scopes });
-  const localUrl = url?.replace('https://fractal.is', 'http://localhost:3000');
 
   const signIn = async () => {
     const width = 400;
@@ -73,7 +72,7 @@ export function SignIn({ clientId, onError, onSuccess, scopes }: SignInProps) {
     const left = window.screenX + (window.innerWidth - width) / 2;
     const top = window.screenY + (window.innerHeight - height) / 2;
     const popup = window.open(
-      localUrl,
+      url,
       'fractal:approval:popup',
       `popup,left=${left},top=${top},width=${width},height=${height},resizable,scrollbars=yes,status=1`,
     );

--- a/src/core/messaging.ts
+++ b/src/core/messaging.ts
@@ -3,4 +3,5 @@ export const FRACTAL_DOMAIN = 'https://www.fractal.is';
 export enum Events {
   PROJECT_APPROVED = 'PROJECT_APPROVED',
   HANDSHAKE = 'HANDSHAKE',
+  HANDSHAKE_ACK = 'HANDSHAKE_ACK',
 }

--- a/src/core/messaging.ts
+++ b/src/core/messaging.ts
@@ -2,4 +2,5 @@ export const FRACTAL_DOMAIN = 'https://www.fractal.is';
 
 export enum Events {
   PROJECT_APPROVED = 'PROJECT_APPROVED',
+  HANDSHAKE = 'HANDSHAKE',
 }


### PR DESCRIPTION
We had to do a few things here of note:

* Send some data through to the popup to let the popup handle retrieving the actual user access token and user ID. Data sent:
  * `clientId`
  * `code` (the auth code retrieved from the auth URL fetcher)
  * `origin` (this is used by the popup to send back the message to the correct origin, not just any origin that listens for messages on the popup.)

This PR depends on [this other PR](https://github.com/fractalwagmi/fractal/pull/817) in the main `fractal` repo.