### PR TITLE
Removes access token from being directly accessible via SDK hook

### DIFF
--- a/src/components/sign-in.tsx
+++ b/src/components/sign-in.tsx
@@ -1,5 +1,5 @@
 import { SignInButton, SignInButtonProps } from 'components/sign-in-button';
-import { maybeGetBaseUserFromLS } from 'core/token';
+import { maybeGetAccessToken, maybeGetBaseUser } from 'core/token';
 import { useUser, useUserSetter } from 'hooks';
 import { useAuthUrl } from 'hooks/use-auth-url';
 import { useSignIn } from 'hooks/use-sign-in';
@@ -75,14 +75,20 @@ export const SignIn = ({
   });
 
   useEffect(() => {
-    const baseUserFromLS = maybeGetBaseUserFromLS();
+    const baseUserFromLS = maybeGetBaseUser();
+    const accessTokenFromLS = maybeGetAccessToken();
     const isAlreadyLoggedIn = Boolean(user);
-    if (isAlreadyLoggedIn || !baseUserFromLS || fetchingUser) {
+    if (
+      isAlreadyLoggedIn ||
+      !baseUserFromLS ||
+      !accessTokenFromLS ||
+      fetchingUser
+    ) {
       return;
     }
 
     const refreshUser = async () => {
-      await fetchAndSetUser(baseUserFromLS);
+      await fetchAndSetUser(baseUserFromLS, accessTokenFromLS);
       setFetchingUser(false);
     };
 

--- a/src/core/token.test.ts
+++ b/src/core/token.test.ts
@@ -1,4 +1,4 @@
-import { maybeGetBaseUserFromLS, storeIdAndTokenInLS } from 'core/token';
+import { maybeGetBaseUser, storeIdAndTokenInLS } from 'core/token';
 import jwtDecode from 'jwt-decode';
 
 jest.mock('jwt-decode');
@@ -14,7 +14,7 @@ describe('storeIdAndTokenInLS', () => {
   });
 });
 
-describe('maybeGetBaseUserFromLS', () => {
+describe('maybeGetBaseUser', () => {
   const SOME_TIMESTAMP_IN_THE_PAST_SEC = (Date.now() - 50000) / 1000;
   const SOME_TIMESTAMP_IN_THE_FUTURE_SEC = (Date.now() + 50000) / 1000;
 
@@ -23,7 +23,7 @@ describe('maybeGetBaseUserFromLS', () => {
     (jwtDecode as jest.Mock).mockReturnValue({
       exp: SOME_TIMESTAMP_IN_THE_PAST_SEC,
     });
-    expect(maybeGetBaseUserFromLS()).toBeUndefined();
+    expect(maybeGetBaseUser()).toBeUndefined();
   });
 
   it('retrieves the base usser if token is unexpired', () => {
@@ -32,8 +32,7 @@ describe('maybeGetBaseUserFromLS', () => {
     });
     storeIdAndTokenInLS({ accessToken: 'foo', userId: 'bar' });
 
-    expect(maybeGetBaseUserFromLS()).toEqual({
-      accessToken: 'foo',
+    expect(maybeGetBaseUser()).toEqual({
       userId: 'bar',
     });
   });
@@ -45,7 +44,7 @@ describe('maybeGetBaseUserFromLS', () => {
     storeIdAndTokenInLS({ accessToken: 'foo', userId: 'bar' });
     localStorage.removeItem(LS_KEY_USER_ID);
 
-    expect(maybeGetBaseUserFromLS()).toBeUndefined();
+    expect(maybeGetBaseUser()).toBeUndefined();
   });
 
   it('returns undefined if only userId is stored in localStorage', () => {
@@ -55,6 +54,6 @@ describe('maybeGetBaseUserFromLS', () => {
     storeIdAndTokenInLS({ accessToken: 'foo', userId: 'bar' });
     localStorage.removeItem(LS_KEY_ACCESS_TOKEN);
 
-    expect(maybeGetBaseUserFromLS()).toBeUndefined();
+    expect(maybeGetBaseUser()).toBeUndefined();
   });
 });

--- a/src/core/token.ts
+++ b/src/core/token.ts
@@ -26,22 +26,34 @@ export function storeIdAndTokenInLS({
  * Returns the base user from localStorage only if it exists and the stored
  * token is unexpired.
  */
-export function maybeGetBaseUserFromLS(): BaseUser | undefined {
+export function maybeGetBaseUser(): BaseUser | undefined {
   if (!window.localStorage) {
     return;
   }
 
-  const accessToken = window.localStorage.getItem(LS_KEY_ACCESS_TOKEN);
+  const accessToken = maybeGetAccessToken();
   const userId = window.localStorage.getItem(LS_KEY_USER_ID);
 
-  if (!accessToken || !userId || isTokenExpired(accessToken)) {
+  if (!accessToken && userId) {
+    window.localStorage.removeItem(LS_KEY_USER_ID);
+  }
+
+  if (!accessToken || !userId) {
     return;
   }
 
   return {
-    accessToken,
     userId,
   };
+}
+
+export function maybeGetAccessToken(): string | undefined {
+  const accessToken = window.localStorage.getItem(LS_KEY_ACCESS_TOKEN);
+  if (!accessToken || isTokenExpired(accessToken)) {
+    window.localStorage.removeItem(LS_KEY_ACCESS_TOKEN);
+    return;
+  }
+  return accessToken;
 }
 
 function isTokenExpired(accessToken: string): boolean {

--- a/src/hooks/public/use-coins.test.tsx
+++ b/src/hooks/public/use-coins.test.tsx
@@ -2,14 +2,16 @@ import { FractalSdkWalletGetCoinsResponseCoin } from '@fractalwagmi/fractal-sdk-
 import { renderHook } from '@testing-library/react-hooks/dom';
 import { UserContextProvider } from 'context/user';
 import { sdkApiClient } from 'core/api/client';
+import * as tokenModule from 'core/token';
 import { useCoins } from 'hooks/public/use-coins';
 import * as useUserModule from 'hooks/public/use-user';
-import { TEST_FRACTAL_USER } from 'hooks/testing/constants';
+import { TEST_ACCESS_TOKEN, TEST_FRACTAL_USER } from 'hooks/testing/constants';
 import { act } from 'react-dom/test-utils';
 import { SWRConfig } from 'swr';
 
 jest.mock('core/api/client');
 jest.mock('hooks/public/use-user');
+jest.mock('core/token');
 
 const ITEM_1: FractalSdkWalletGetCoinsResponseCoin = {
   address: 'test-address-1',
@@ -32,11 +34,15 @@ const ITEM_2: FractalSdkWalletGetCoinsResponseCoin = {
 };
 
 describe('useCoins', () => {
+  let mockMaybeGetAccessToken: jest.SpyInstance;
   let mockGetCoins: jest.SpyInstance;
   let mockUseUser: jest.SpyInstance;
   let wrapper: React.FC;
 
   beforeEach(() => {
+    mockMaybeGetAccessToken = jest.spyOn(tokenModule, 'maybeGetAccessToken');
+    mockMaybeGetAccessToken.mockReturnValue(TEST_ACCESS_TOKEN);
+
     mockGetCoins = jest.spyOn(sdkApiClient.v1, 'getCoins');
     mockGetCoins.mockResolvedValue([]);
 
@@ -102,7 +108,7 @@ describe('useCoins', () => {
     expect(mockGetCoins).toHaveBeenLastCalledWith(
       expect.objectContaining({
         headers: {
-          authorization: `Bearer ${TEST_FRACTAL_USER.accessToken}`,
+          authorization: `Bearer ${TEST_ACCESS_TOKEN}`,
         },
       }),
     );

--- a/src/hooks/public/use-coins.ts
+++ b/src/hooks/public/use-coins.ts
@@ -2,6 +2,7 @@ import { sdkApiClient } from 'core/api/client';
 import { Endpoint } from 'core/api/endpoints';
 import { maybeIncludeAuthorizationHeaders } from 'core/api/headers';
 import { processCoins } from 'core/api/processors/coins';
+import { maybeGetAccessToken } from 'core/token';
 import { PublicHookResponse } from 'hooks/public/types';
 import { useUser } from 'hooks/public/use-user';
 import { useCallback, useMemo, useState } from 'react';
@@ -10,6 +11,7 @@ import { Coin } from 'types';
 
 export const useCoins = (): PublicHookResponse<Coin[]> => {
   const { data: user } = useUser();
+  const accessToken = maybeGetAccessToken();
   const [fetchToken, setFetchToken] = useState(0);
 
   const refetch = useCallback(() => {
@@ -17,7 +19,7 @@ export const useCoins = (): PublicHookResponse<Coin[]> => {
   }, [fetchToken]);
 
   const requestKey = user
-    ? [Endpoint.GET_COINS, user.accessToken, user.userId, fetchToken]
+    ? [Endpoint.GET_COINS, accessToken, user.userId, fetchToken]
     : null;
   const { data, error } = useSWR(
     requestKey,
@@ -25,7 +27,7 @@ export const useCoins = (): PublicHookResponse<Coin[]> => {
       (
         await sdkApiClient.v1.getCoins({
           headers: maybeIncludeAuthorizationHeaders(
-            user?.accessToken ?? '',
+            accessToken ?? '',
             Endpoint.GET_COINS,
           ),
         })

--- a/src/hooks/public/use-items.test.tsx
+++ b/src/hooks/public/use-items.test.tsx
@@ -2,12 +2,14 @@ import { FractalSdkWalletGetItemsResponseItem } from '@fractalwagmi/fractal-sdk-
 import { renderHook } from '@testing-library/react-hooks/dom';
 import { UserContextProvider } from 'context/user';
 import { sdkApiClient } from 'core/api/client';
+import * as tokenModule from 'core/token';
 import { useItems } from 'hooks/public/use-items';
 import * as useUserModule from 'hooks/public/use-user';
-import { TEST_FRACTAL_USER } from 'hooks/testing/constants';
+import { TEST_ACCESS_TOKEN, TEST_FRACTAL_USER } from 'hooks/testing/constants';
 import { act } from 'react-dom/test-utils';
 import { SWRConfig } from 'swr';
 
+jest.mock('core/token');
 jest.mock('core/api/client');
 jest.mock('hooks/public/use-user');
 
@@ -42,11 +44,15 @@ const ITEM_2: FractalSdkWalletGetItemsResponseItem = {
 };
 
 describe('useItems', () => {
+  let mockMaybeGetAccessToken: jest.SpyInstance;
   let mockGetWalletItems: jest.SpyInstance;
   let mockGetUser: jest.SpyInstance;
   let wrapper: React.FC;
 
   beforeEach(() => {
+    mockMaybeGetAccessToken = jest.spyOn(tokenModule, 'maybeGetAccessToken');
+    mockMaybeGetAccessToken.mockReturnValue(TEST_ACCESS_TOKEN);
+
     mockGetWalletItems = jest.spyOn(sdkApiClient.v1, 'getWalletItems');
     mockGetWalletItems.mockResolvedValue([]);
 
@@ -112,7 +118,7 @@ describe('useItems', () => {
     expect(mockGetWalletItems).toHaveBeenLastCalledWith(
       expect.objectContaining({
         headers: {
-          authorization: `Bearer ${TEST_FRACTAL_USER.accessToken}`,
+          authorization: `Bearer ${TEST_ACCESS_TOKEN}`,
         },
       }),
     );

--- a/src/hooks/public/use-items.ts
+++ b/src/hooks/public/use-items.ts
@@ -2,6 +2,7 @@ import { sdkApiClient } from 'core/api/client';
 import { Endpoint } from 'core/api/endpoints';
 import { maybeIncludeAuthorizationHeaders } from 'core/api/headers';
 import { processItems } from 'core/api/processors/items';
+import { maybeGetAccessToken } from 'core/token';
 import { PublicHookResponse } from 'hooks/public/types';
 import { useUser } from 'hooks/public/use-user';
 import { useCallback, useMemo, useState } from 'react';
@@ -10,6 +11,7 @@ import { Item } from 'types';
 
 export const useItems = (): PublicHookResponse<Item[]> => {
   const { data: user } = useUser();
+  const accessToken = maybeGetAccessToken();
   const [fetchToken, setFetchToken] = useState(0);
 
   const refetch = useCallback(() => {
@@ -17,7 +19,7 @@ export const useItems = (): PublicHookResponse<Item[]> => {
   }, [fetchToken]);
 
   const requestKey = user
-    ? [Endpoint.GET_WALLET_ITEMS, user.accessToken, user.userId, fetchToken]
+    ? [Endpoint.GET_WALLET_ITEMS, accessToken, user.userId, fetchToken]
     : null;
 
   const { data, error } = useSWR(
@@ -26,7 +28,7 @@ export const useItems = (): PublicHookResponse<Item[]> => {
       (
         await sdkApiClient.v1.getWalletItems({
           headers: maybeIncludeAuthorizationHeaders(
-            user?.accessToken ?? '',
+            accessToken ?? '',
             Endpoint.GET_WALLET_ITEMS,
           ),
         })

--- a/src/hooks/testing/constants.ts
+++ b/src/hooks/testing/constants.ts
@@ -6,7 +6,6 @@ export const TEST_USER_EMAIL = 'test-user@email.com';
 export const TEST_USERNAME = 'test-username';
 
 export const TEST_FRACTAL_USER: User = {
-  accessToken: TEST_ACCESS_TOKEN,
   email: TEST_USER_EMAIL,
   userId: TEST_USER_ID,
   username: TEST_USERNAME,

--- a/src/hooks/use-sign-in.ts
+++ b/src/hooks/use-sign-in.ts
@@ -2,7 +2,7 @@ import { Events, validateOrigin } from 'core/messaging';
 import { openPopup, POPUP_HEIGHT_PX, POPUP_WIDTH_PX } from 'core/popup';
 import { useUserSetter } from 'hooks/use-user-setter';
 import { useCallback } from 'react';
-import { User } from 'types';
+import { BaseUser, User } from 'types';
 
 interface UseSignInParameters {
   clientId: string;
@@ -64,8 +64,10 @@ export const useSignIn = ({
         }
         if (e.data.event === Events.PROJECT_APPROVED) {
           try {
-            const baseUser = e.data.payload.user;
-            const { user } = await fetchAndSetUser(baseUser);
+            const userId = e.data.payload.user.id;
+            const accessToken = e.data.payload.user.accessToken;
+            const baseUser: BaseUser = { userId };
+            const { user } = await fetchAndSetUser(baseUser, accessToken);
             popup.close();
             onSignIn(user);
           } catch (e: unknown) {

--- a/src/hooks/use-user-setter.test.tsx
+++ b/src/hooks/use-user-setter.test.tsx
@@ -18,7 +18,6 @@ const EXPECTED_AUTHORIZATION_HEADER = {
   authorization: `Bearer ${TEST_ACCESS_TOKEN}`,
 };
 const DEFAULT_PARAMS = {
-  accessToken: TEST_ACCESS_TOKEN,
   userId: TEST_USER_ID,
 };
 
@@ -39,7 +38,7 @@ describe('useUserSetter', () => {
   it('includes an authorization header when fetching user info', async () => {
     const { result } = renderHook(() => useUserSetter());
 
-    await result.current.fetchAndSetUser(DEFAULT_PARAMS);
+    await result.current.fetchAndSetUser(DEFAULT_PARAMS, TEST_ACCESS_TOKEN);
 
     expect(mockGetInfo).lastCalledWith(
       expect.objectContaining({
@@ -52,10 +51,12 @@ describe('useUserSetter', () => {
     it('returns an object with fractal user', async () => {
       const { result } = renderHook(() => useUserSetter());
 
-      const { user } = await result.current.fetchAndSetUser(DEFAULT_PARAMS);
+      const { user } = await result.current.fetchAndSetUser(
+        DEFAULT_PARAMS,
+        TEST_ACCESS_TOKEN,
+      );
 
       expect(user).toEqual({
-        accessToken: TEST_ACCESS_TOKEN,
         email: TEST_EMAIL,
         userId: TEST_USER_ID,
         username: TEST_USERNAME,
@@ -67,6 +68,7 @@ describe('useUserSetter', () => {
 
       const { userWallet } = await result.current.fetchAndSetUser(
         DEFAULT_PARAMS,
+        TEST_ACCESS_TOKEN,
       );
 
       expect(userWallet).toEqual({
@@ -95,11 +97,11 @@ describe('useUserSetter', () => {
       await act(async () => {
         await result.current.useUserSetterResult.fetchAndSetUser(
           DEFAULT_PARAMS,
+          TEST_ACCESS_TOKEN,
         );
       });
 
       expect(result.current.useUserResult.data).toEqual({
-        accessToken: TEST_ACCESS_TOKEN,
         email: TEST_EMAIL,
         userId: TEST_USER_ID,
         username: TEST_USERNAME,
@@ -127,6 +129,7 @@ describe('useUserSetter', () => {
       await act(async () => {
         await result.current.useUserSetterResult.fetchAndSetUser(
           DEFAULT_PARAMS,
+          TEST_ACCESS_TOKEN,
         );
       });
 

--- a/src/hooks/use-user-setter.ts
+++ b/src/hooks/use-user-setter.ts
@@ -9,35 +9,38 @@ import { UserWallet, BaseUser, User } from 'types';
 export const useUserSetter = () => {
   const { setUser, setUserWallet } = useContext(UserContext);
 
-  const fetchAndSetUser = useCallback(async (baseUser: BaseUser) => {
-    const { data } = await sdkApiClient.v1.getInfo({
-      headers: maybeIncludeAuthorizationHeaders(
-        baseUser.accessToken,
-        Endpoint.GET_INFO,
-      ),
-    });
+  const fetchAndSetUser = useCallback(
+    async (baseUser: BaseUser, accessToken: string) => {
+      const { data } = await sdkApiClient.v1.getInfo({
+        headers: maybeIncludeAuthorizationHeaders(
+          accessToken,
+          Endpoint.GET_INFO,
+        ),
+      });
 
-    const user: User = {
-      ...baseUser,
-      email: data.email,
-      username: data.username,
-    };
-    const userWallet: UserWallet = {
-      solanaPublicKeys: data.accountPublicKey ? [data.accountPublicKey] : [],
-    };
+      const user: User = {
+        ...baseUser,
+        email: data.email,
+        username: data.username,
+      };
+      const userWallet: UserWallet = {
+        solanaPublicKeys: data.accountPublicKey ? [data.accountPublicKey] : [],
+      };
 
-    storeIdAndTokenInLS({
-      accessToken: user.accessToken,
-      userId: user.userId,
-    });
-    setUser(user);
-    setUserWallet(userWallet);
+      storeIdAndTokenInLS({
+        accessToken,
+        userId: user.userId,
+      });
+      setUser(user);
+      setUserWallet(userWallet);
 
-    return {
-      user,
-      userWallet,
-    };
-  }, []);
+      return {
+        user,
+        userWallet,
+      };
+    },
+    [],
+  );
 
   return {
     fetchAndSetUser,

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,7 +1,4 @@
 export interface BaseUser {
-  /** The oauth access token used to authenticate with API calls to the SDK API. */
-  accessToken: string;
-
   /** A user identifier within Fractal. */
   userId: string;
 }


### PR DESCRIPTION
Right now, the `accessToken` is accessible on the `BaseUser` interface, which is exported to calling code via the `useUser` hook.

This `accessToken` is an implementation detail so this PR makes it so that `useUser` no longer exposes the `accessToken`.