### PR TITLE
Adds core error structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ const App = () => {
 This will display a button for logging in.
 
 ```tsx
-import { Scope, SignInWithFractal, User } from '@fractalwagmi/fractal-sdk';
+import {
+  Scope,
+  SignInWithFractal,
+  User,
+  FractalError,
+} from '@fractalwagmi/fractal-sdk';
 
 export function YourSignInComponent() {
   return (
@@ -47,8 +52,8 @@ export function YourSignInComponent() {
       clientId="YOUR_CLIENT_ID"
       // `scopes` defaults to [Scope.IDENTIFY].
       scopes={[Scope.IDENTIFY, Scope.ITEMS_READ, Scope.COINS_READ]}
-      onError={err => {
-        console.log('err = ', err);
+      onError={(err: FractalError) => {
+        console.log(err.getUserFacingErrorMessage());
       }}
       onSuccess={(user: User) => {
         console.log('user = ', user);
@@ -87,7 +92,7 @@ You can customize the look of the button with either of these options:
 | `clientId`         | `string`<br/>(Required) The client ID to use.                                                                                        | n/a                |
 | `component`        | `React.ReactElement`<br/>Optional component to render instead of the default sign-in button                                          | `undefined`        |
 | `hideWhenSignedIn` | `boolean`<br/>Whether to hide the sign in button when logged in or not.                                                              | `true`             |
-| `onError`          | `(e: unknown) => void`<br/>A callback function to call when an error occurs.                                                         | `undefined`        |
+| `onError`          | `(e: FractalError) => void`<br/>A callback function to call when an error occurs.                                                    | `undefined`        |
 | `onSuccess`        | `(user: User) => void`<br/>A callback function to call when a user successfully logs in.                                             | `undefined`        |
 | `scopes`           | `Scope[]`<br/>The scope to assign to the access token. See [src/types/scope.ts](/src/types/scope.ts) for a list of available scopes. | `[Scope.IDENTIFY]` |
 | `variant`          | `"light" \| "dark"`<br/>The button style variant to use.                                                                             | `"light"`          |

--- a/src/components/sign-in.tsx
+++ b/src/components/sign-in.tsx
@@ -1,4 +1,5 @@
 import { SignInButton, SignInButtonProps } from 'components/sign-in-button';
+import { FractalError } from 'core/error';
 import { maybeGetAccessToken, maybeGetBaseUser } from 'core/token';
 import { useUser, useUserSetter } from 'hooks';
 import { useAuthUrl } from 'hooks/use-auth-url';
@@ -17,7 +18,7 @@ export interface SignInProps {
   component?: React.ReactElement;
   /** Whether to hide the sign in button when logged in or not. Defaults to `true`. */
   hideWhenSignedIn?: boolean;
-  onError?: (e: unknown) => void;
+  onError?: (e: FractalError) => void;
   onSuccess?: (user: User) => void;
   /**
    * The scopes to assign to the access token. Defaults to [Scope.IDENTIFY].
@@ -47,7 +48,7 @@ export const SignIn = ({
   const [fetchingUser, setFetchingUser] = useState(false);
   const { fetchAndSetUser } = useUserSetter();
 
-  const doError = (e: unknown) => {
+  const doError = (e: FractalError) => {
     if (!onError) {
       return;
     }

--- a/src/core/error/index.ts
+++ b/src/core/error/index.ts
@@ -1,0 +1,14 @@
+export class FractalError extends Error {
+  name: string;
+  constructor(message: string) {
+    super(message);
+    this.name = 'FractalError';
+
+    // 👇️ because we are extending a built-in class
+    Object.setPrototypeOf(this, FractalError.prototype);
+  }
+
+  getUserFacingErrorMessage() {
+    return 'Something went wrong: ' + this.message;
+  }
+}

--- a/src/hooks/public/types.ts
+++ b/src/hooks/public/types.ts
@@ -1,5 +1,7 @@
+import { FractalError } from 'core/error';
+
 export interface PublicHookResponse<T> {
   data: T;
-  error: unknown;
+  error: FractalError | undefined;
   refetch: () => void;
 }

--- a/src/hooks/public/use-coins.ts
+++ b/src/hooks/public/use-coins.ts
@@ -2,6 +2,7 @@ import { sdkApiClient } from 'core/api/client';
 import { Endpoint } from 'core/api/endpoints';
 import { maybeIncludeAuthorizationHeaders } from 'core/api/headers';
 import { transformCoins } from 'core/api/transformers/coins';
+import { FractalError } from 'core/error';
 import { maybeGetAccessToken } from 'core/token';
 import { PublicHookResponse } from 'hooks/public/types';
 import { useUser } from 'hooks/public/use-user';
@@ -21,7 +22,7 @@ export const useCoins = (): PublicHookResponse<Coin[]> => {
   const requestKey = user
     ? [Endpoint.GET_COINS, user.userId, fetchToken]
     : null;
-  const { data, error } = useSWR(
+  const { data, error: errorResponse } = useSWR(
     requestKey,
     async () =>
       (
@@ -35,6 +36,12 @@ export const useCoins = (): PublicHookResponse<Coin[]> => {
   );
 
   const coins = useMemo(() => transformCoins(data?.coins ?? []), [data?.coins]);
+
+  let error: FractalError | undefined;
+  if (errorResponse) {
+    // TODO(ENG-394): Enumerate possible errors.
+    error = new FractalError('Unable to retrieve coins');
+  }
 
   return {
     data: coins,

--- a/src/hooks/public/use-items.ts
+++ b/src/hooks/public/use-items.ts
@@ -2,6 +2,7 @@ import { sdkApiClient } from 'core/api/client';
 import { Endpoint } from 'core/api/endpoints';
 import { maybeIncludeAuthorizationHeaders } from 'core/api/headers';
 import { transformItems } from 'core/api/transformers/items';
+import { FractalError } from 'core/error';
 import { maybeGetAccessToken } from 'core/token';
 import { PublicHookResponse } from 'hooks/public/types';
 import { useUser } from 'hooks/public/use-user';
@@ -22,7 +23,7 @@ export const useItems = (): PublicHookResponse<Item[]> => {
     ? [Endpoint.GET_WALLET_ITEMS, user.userId, fetchToken]
     : null;
 
-  const { data, error } = useSWR(
+  const { data, error: responseError } = useSWR(
     requestKey,
     async () =>
       (
@@ -37,6 +38,11 @@ export const useItems = (): PublicHookResponse<Item[]> => {
 
   const items = useMemo(() => transformItems(data?.items ?? []), [data?.items]);
 
+  let error: FractalError | undefined;
+  if (responseError) {
+    // TODO(ENG-394): Enumerate possible errors.
+    error = new FractalError('Unable to retrieve coins');
+  }
   return {
     data: items,
     error,

--- a/src/hooks/use-auth-url.test.ts
+++ b/src/hooks/use-auth-url.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks/dom';
 import { authApiClient } from 'core/api/client';
+import { FractalError } from 'core/error';
 import { useAuthUrl } from 'hooks/use-auth-url';
 import { EMPTY_FN_RETURNS_UNDEFINED } from 'lib/__data__/constants';
 import { act } from 'react-dom/test-utils';
@@ -102,9 +103,8 @@ describe('useAuthUrl', () => {
     expect(result.current.url).toBe(TEST_RETURNED_URL);
   });
 
-  it('calls `onError` when an error occurs', async () => {
-    const error = new Error('some error');
-    (authApiClient.v2.getUrl as jest.Mock).mockRejectedValueOnce(error);
+  it('calls `onError` with a `FractalError` when an error occurs', async () => {
+    (authApiClient.v2.getUrl as jest.Mock).mockRejectedValueOnce(new Error());
     const onError = jest.fn();
     renderHook(() =>
       useAuthUrl({
@@ -118,6 +118,6 @@ describe('useAuthUrl', () => {
       await 0;
     });
 
-    expect(onError).toHaveBeenCalledWith(error);
+    expect(onError.mock.lastCall[0]).toBeInstanceOf(FractalError);
   });
 });

--- a/src/hooks/use-auth-url.ts
+++ b/src/hooks/use-auth-url.ts
@@ -1,4 +1,5 @@
 import { authApiClient } from 'core/api/client';
+import { FractalError } from 'core/error';
 import { verifyScopes } from 'core/scope';
 import { useEffect, useState } from 'react';
 import { Scope } from 'types';
@@ -7,7 +8,7 @@ const DEFAULT_SCOPE = [Scope.IDENTIFY];
 
 interface UseAuthUrlParameters {
   clientId: string;
-  onError: (e: unknown) => void;
+  onError: (e: FractalError) => void;
   scopes?: Scope[];
 }
 
@@ -41,7 +42,8 @@ export const useAuthUrl = ({
         setUrl(urlInfo.url);
         setCode(urlInfo.code);
       } catch (e: unknown) {
-        onError(e);
+        // TODO: Add sentry integration.
+        onError(new FractalError('Unable to retrieve auth URL'));
       }
     };
     getUrl();

--- a/src/hooks/use-sign-in.ts
+++ b/src/hooks/use-sign-in.ts
@@ -1,3 +1,4 @@
+import { FractalError } from 'core/error';
 import { Events, validateOrigin } from 'core/messaging';
 import { openPopup, POPUP_HEIGHT_PX, POPUP_WIDTH_PX } from 'core/popup';
 import { useUserSetter } from 'hooks/use-user-setter';
@@ -8,7 +9,7 @@ interface UseSignInParameters {
   clientId: string;
   code: string | undefined;
   onSignIn: (user: User) => void;
-  onSignInFailed: (e: unknown) => void;
+  onSignInFailed: (e: FractalError) => void;
   url: string | undefined;
 }
 
@@ -66,7 +67,8 @@ export const useSignIn = ({
             popup.close();
             onSignIn(user);
           } catch (e: unknown) {
-            onSignInFailed(e);
+            // TODO: Add sentry integration.
+            onSignInFailed(new FractalError('Sign in failed.'));
           }
         }
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { SignIn as SignInWithFractal } from 'components/sign-in';
 export { UserContextProvider as FractalProvider } from 'context/user';
 export type { SignInProps } from 'components/sign-in';
 
+export { FractalError } from 'core/error';
 export { Scope } from 'types';
 export type { User, UserWallet, Coin, Item } from 'types';
 


### PR DESCRIPTION
As title.

We'll extend `FractalError` for more specific error enumerations, but this will get us in a place where things are reliably returning a known error object type instead of `unknown`.

I looked into a couple of different options for how to surface errors, but I think just extending `Error` with `FractalError` as a baseline and creating new classes that inherit from `FractalError` for specific error instances is a reasonable pattern.