### PR TITLE
0.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fractalwagmi/fractal-sdk",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractalwagmi/fractal-sdk",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@emotion/css": "^11.10.0",
         "@fontsource/quattrocento-sans": "^4.5.9",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   },
   "homepage": "https://github.com/fractalwagmi/fractal-sdk#readme",
   "peerDependencies": {
-    "react": "^17.0.2 || ^18.0.0-0",
-    "react-dom": "^17.0.2 || ^18.0.0-0"
+    "react": ">=17.0.3 <=18.2.0",
+    "react-dom": ">=17.0.3 <=18.2.0"
   },
   "dependencies": {
     "@emotion/css": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   },
   "homepage": "https://github.com/fractalwagmi/fractal-sdk#readme",
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "17.0.2"
+    "react": "^17.0.2 || ^18.0.0-0",
+    "react-dom": "^17.0.2 || ^18.0.0-0"
   },
   "dependencies": {
     "@emotion/css": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractalwagmi/fractal-sdk",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Fractal Client SDK to install Fractal Wallet and access Fractal SDKs/APIs.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Right now, if a host app uses react 18 (tested using sdk-demo,) `npm install` will throw an error unless used with `--legacy-peer-deps`.

This new version prevents that.