### PR TITLE
Renames `FractalError` to `FractalSDKError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import {
   Scope,
   SignInWithFractal,
   User,
-  FractalError,
+  FractalSDKError,
 } from '@fractalwagmi/fractal-sdk';
 
 export function YourSignInComponent() {
@@ -52,7 +52,7 @@ export function YourSignInComponent() {
       clientId="YOUR_CLIENT_ID"
       // `scopes` defaults to [Scope.IDENTIFY].
       scopes={[Scope.IDENTIFY, Scope.ITEMS_READ, Scope.COINS_READ]}
-      onError={(err: FractalError) => {
+      onError={(err: FractalSDKError) => {
         console.log(err.getUserFacingErrorMessage());
       }}
       onSuccess={(user: User) => {
@@ -92,7 +92,7 @@ You can customize the look of the button with either of these options:
 | `clientId`         | `string`<br/>(Required) The client ID to use.                                                                                        | n/a                |
 | `component`        | `React.ReactElement`<br/>Optional component to render instead of the default sign-in button                                          | `undefined`        |
 | `hideWhenSignedIn` | `boolean`<br/>Whether to hide the sign in button when logged in or not.                                                              | `true`             |
-| `onError`          | `(e: FractalError) => void`<br/>A callback function to call when an error occurs.                                                    | `undefined`        |
+| `onError`          | `(e: FractalSDKError) => void`<br/>A callback function to call when an error occurs.                                                 | `undefined`        |
 | `onSuccess`        | `(user: User) => void`<br/>A callback function to call when a user successfully logs in.                                             | `undefined`        |
 | `scopes`           | `Scope[]`<br/>The scope to assign to the access token. See [src/types/scope.ts](/src/types/scope.ts) for a list of available scopes. | `[Scope.IDENTIFY]` |
 | `variant`          | `"light" \| "dark"`<br/>The button style variant to use.                                                                             | `"light"`          |

--- a/src/components/sign-in.tsx
+++ b/src/components/sign-in.tsx
@@ -1,5 +1,5 @@
 import { SignInButton, SignInButtonProps } from 'components/sign-in-button';
-import { FractalError } from 'core/error';
+import { FractalSDKError } from 'core/error';
 import { maybeGetAccessToken, maybeGetBaseUser } from 'core/token';
 import { useUser, useUserSetter } from 'hooks';
 import { useAuthUrl } from 'hooks/use-auth-url';
@@ -18,7 +18,7 @@ export interface SignInProps {
   component?: React.ReactElement;
   /** Whether to hide the sign in button when logged in or not. Defaults to `true`. */
   hideWhenSignedIn?: boolean;
-  onError?: (e: FractalError) => void;
+  onError?: (e: FractalSDKError) => void;
   onSuccess?: (user: User) => void;
   /**
    * The scopes to assign to the access token. Defaults to [Scope.IDENTIFY].
@@ -48,7 +48,7 @@ export const SignIn = ({
   const [fetchingUser, setFetchingUser] = useState(false);
   const { fetchAndSetUser } = useUserSetter();
 
-  const doError = (e: FractalError) => {
+  const doError = (e: FractalSDKError) => {
     if (!onError) {
       return;
     }

--- a/src/core/error/index.ts
+++ b/src/core/error/index.ts
@@ -1,11 +1,11 @@
-export class FractalError extends Error {
+export class FractalSDKError extends Error {
   name: string;
   constructor(message: string) {
     super(message);
-    this.name = 'FractalError';
+    this.name = 'FractalSDKError';
 
     // 👇️ because we are extending a built-in class
-    Object.setPrototypeOf(this, FractalError.prototype);
+    Object.setPrototypeOf(this, FractalSDKError.prototype);
   }
 
   getUserFacingErrorMessage() {

--- a/src/hooks/public/types.ts
+++ b/src/hooks/public/types.ts
@@ -1,7 +1,7 @@
-import { FractalError } from 'core/error';
+import { FractalSDKError } from 'core/error';
 
 export interface PublicHookResponse<T> {
   data: T;
-  error: FractalError | undefined;
+  error: FractalSDKError | undefined;
   refetch: () => void;
 }

--- a/src/hooks/public/use-coins.ts
+++ b/src/hooks/public/use-coins.ts
@@ -2,7 +2,7 @@ import { sdkApiClient } from 'core/api/client';
 import { Endpoint } from 'core/api/endpoints';
 import { maybeIncludeAuthorizationHeaders } from 'core/api/headers';
 import { transformCoins } from 'core/api/transformers/coins';
-import { FractalError } from 'core/error';
+import { FractalSDKError } from 'core/error';
 import { maybeGetAccessToken } from 'core/token';
 import { PublicHookResponse } from 'hooks/public/types';
 import { useUser } from 'hooks/public/use-user';
@@ -37,10 +37,10 @@ export const useCoins = (): PublicHookResponse<Coin[]> => {
 
   const coins = useMemo(() => transformCoins(data?.coins ?? []), [data?.coins]);
 
-  let error: FractalError | undefined;
+  let error: FractalSDKError | undefined;
   if (errorResponse) {
     // TODO(ENG-394): Enumerate possible errors.
-    error = new FractalError('Unable to retrieve coins');
+    error = new FractalSDKError('Unable to retrieve coins');
   }
 
   return {

--- a/src/hooks/public/use-items.ts
+++ b/src/hooks/public/use-items.ts
@@ -2,7 +2,7 @@ import { sdkApiClient } from 'core/api/client';
 import { Endpoint } from 'core/api/endpoints';
 import { maybeIncludeAuthorizationHeaders } from 'core/api/headers';
 import { transformItems } from 'core/api/transformers/items';
-import { FractalError } from 'core/error';
+import { FractalSDKError } from 'core/error';
 import { maybeGetAccessToken } from 'core/token';
 import { PublicHookResponse } from 'hooks/public/types';
 import { useUser } from 'hooks/public/use-user';
@@ -38,10 +38,10 @@ export const useItems = (): PublicHookResponse<Item[]> => {
 
   const items = useMemo(() => transformItems(data?.items ?? []), [data?.items]);
 
-  let error: FractalError | undefined;
+  let error: FractalSDKError | undefined;
   if (responseError) {
     // TODO(ENG-394): Enumerate possible errors.
-    error = new FractalError('Unable to retrieve coins');
+    error = new FractalSDKError('Unable to retrieve coins');
   }
   return {
     data: items,

--- a/src/hooks/use-auth-url.test.ts
+++ b/src/hooks/use-auth-url.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks/dom';
 import { authApiClient } from 'core/api/client';
-import { FractalError } from 'core/error';
+import { FractalSDKError } from 'core/error';
 import { useAuthUrl } from 'hooks/use-auth-url';
 import { EMPTY_FN_RETURNS_UNDEFINED } from 'lib/__data__/constants';
 import { act } from 'react-dom/test-utils';
@@ -103,7 +103,7 @@ describe('useAuthUrl', () => {
     expect(result.current.url).toBe(TEST_RETURNED_URL);
   });
 
-  it('calls `onError` with a `FractalError` when an error occurs', async () => {
+  it('calls `onError` with a `FractalSDKError` when an error occurs', async () => {
     (authApiClient.v2.getUrl as jest.Mock).mockRejectedValueOnce(new Error());
     const onError = jest.fn();
     renderHook(() =>
@@ -118,6 +118,6 @@ describe('useAuthUrl', () => {
       await 0;
     });
 
-    expect(onError.mock.lastCall[0]).toBeInstanceOf(FractalError);
+    expect(onError.mock.lastCall[0]).toBeInstanceOf(FractalSDKError);
   });
 });

--- a/src/hooks/use-auth-url.ts
+++ b/src/hooks/use-auth-url.ts
@@ -1,5 +1,5 @@
 import { authApiClient } from 'core/api/client';
-import { FractalError } from 'core/error';
+import { FractalSDKError } from 'core/error';
 import { verifyScopes } from 'core/scope';
 import { useEffect, useState } from 'react';
 import { Scope } from 'types';
@@ -8,7 +8,7 @@ const DEFAULT_SCOPE = [Scope.IDENTIFY];
 
 interface UseAuthUrlParameters {
   clientId: string;
-  onError: (e: FractalError) => void;
+  onError: (e: FractalSDKError) => void;
   scopes?: Scope[];
 }
 
@@ -43,7 +43,7 @@ export const useAuthUrl = ({
         setCode(urlInfo.code);
       } catch (e: unknown) {
         // TODO: Add sentry integration.
-        onError(new FractalError('Unable to retrieve auth URL'));
+        onError(new FractalSDKError('Unable to retrieve auth URL'));
       }
     };
     getUrl();

--- a/src/hooks/use-sign-in.ts
+++ b/src/hooks/use-sign-in.ts
@@ -1,4 +1,4 @@
-import { FractalError } from 'core/error';
+import { FractalSDKError } from 'core/error';
 import { Events, validateOrigin } from 'core/messaging';
 import { openPopup, POPUP_HEIGHT_PX, POPUP_WIDTH_PX } from 'core/popup';
 import { useUserSetter } from 'hooks/use-user-setter';
@@ -9,7 +9,7 @@ interface UseSignInParameters {
   clientId: string;
   code: string | undefined;
   onSignIn: (user: User) => void;
-  onSignInFailed: (e: FractalError) => void;
+  onSignInFailed: (e: FractalSDKError) => void;
   url: string | undefined;
 }
 
@@ -68,7 +68,7 @@ export const useSignIn = ({
             onSignIn(user);
           } catch (e: unknown) {
             // TODO: Add sentry integration.
-            onSignInFailed(new FractalError('Sign in failed.'));
+            onSignInFailed(new FractalSDKError('Sign in failed.'));
           }
         }
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,18 @@
+import { FractalSDKError } from 'core/error';
+
 export { SignIn as SignInWithFractal } from 'components/sign-in';
 export { UserContextProvider as FractalProvider } from 'context/user';
 export type { SignInProps } from 'components/sign-in';
 
-export { FractalError } from 'core/error';
+export { FractalSDKError } from 'core/error';
 export { Scope } from 'types';
 export type { User, UserWallet, Coin, Item } from 'types';
 
+// TODO: Remove FractalError in next major version, maintaining for backwards
+// compatibility.
+/**
+ * @deprecated Use `FractalSDKError`. The `FractalError` alias will be removed
+ *   in the next version.
+ */
+export const FractalError = FractalSDKError;
 export * from 'hooks/public';


### PR DESCRIPTION
As title.

I kept `FractalError` as to prevent updating the major version since I didn't want to introduce a breaking change.... (I know no one is likely using the SDK at this point, but just wanted to get in the practice of using semver correctly.)

LMK if you think its overkill.