### PR TITLE
[BREAKING CHANGE] Moves `clientId` as a prop from `SignIn` to `FractalProvider`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Render the provider above any components that need access to data from the SDK.
 import { FractalProvider } from '@fractalwagmi/fractal-sdk';
 
 const App = () => {
-  return <FractalProvider>...</FractalProvider>;
+  return <FractalProvider clientId="YOUR_CLIENT_ID">...</FractalProvider>;
 };
 ```
 
@@ -48,8 +48,6 @@ import {
 export function YourSignInComponent() {
   return (
     <SignInWithFractal
-      // The `clientId` is the only required prop.
-      clientId="YOUR_CLIENT_ID"
       // `scopes` defaults to [Scope.IDENTIFY].
       scopes={[Scope.IDENTIFY, Scope.ITEMS_READ, Scope.COINS_READ]}
       onError={(err: FractalSDKError) => {
@@ -69,19 +67,19 @@ By default, there are 2 button variants that we support:
 
 ```tsx
 // There is a "light" (default) and "dark" variant:
-<SignInWithFractal clientId="..." variant="dark">
+<SignInWithFractal variant="dark">
 ```
 
 You can customize the look of the button with either of these options:
 
 ```tsx
 // Using your own class name to override any default styles:
-<SignInWithFractal clientId="..." className="foobar">
+<SignInWithFractal className="foobar">
 ```
 
 ```tsx
 // Use your own child component:
-<SignInWithFractal clientId="..." component={<YourOwnButton />}>
+<SignInWithFractal component={<YourOwnButton />}>
 ```
 
 #### SignInWithFractal Props
@@ -89,7 +87,6 @@ You can customize the look of the button with either of these options:
 | Prop               | Type / Description                                                                                                                   | Default            |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
 | `buttonProps`      | `HTMLAttributes<HTMLButtonElement>`<br/>Any additional props for `<button>` that should be passed to the default sign-in button.     | `{}`               |
-| `clientId`         | `string`<br/>(Required) The client ID to use.                                                                                        | n/a                |
 | `component`        | `React.ReactElement`<br/>Optional component to render instead of the default sign-in button                                          | `undefined`        |
 | `hideWhenSignedIn` | `boolean`<br/>Whether to hide the sign in button when logged in or not.                                                              | `true`             |
 | `onError`          | `(e: FractalSDKError) => void`<br/>A callback function to call when an error occurs.                                                 | `undefined`        |

--- a/src/components/sign-in.tsx
+++ b/src/components/sign-in.tsx
@@ -1,10 +1,11 @@
 import { SignInButton, SignInButtonProps } from 'components/sign-in-button';
+import { FractalSDKContext } from 'context/fractal-sdk-context';
 import { FractalSDKError } from 'core/error';
 import { maybeGetAccessToken, maybeGetBaseUser } from 'core/token';
 import { useUser, useUserSetter } from 'hooks';
 import { useAuthUrl } from 'hooks/use-auth-url';
 import { useSignIn } from 'hooks/use-sign-in';
-import React, { HTMLAttributes, useEffect, useState } from 'react';
+import React, { HTMLAttributes, useContext, useEffect, useState } from 'react';
 import { Scope, User } from 'types';
 
 export interface SignInProps {
@@ -13,7 +14,6 @@ export interface SignInProps {
    * sign-in button.
    */
   buttonProps?: HTMLAttributes<HTMLButtonElement>;
-  clientId: string;
   /** Optional component to render instead of the default sign-in button. */
   component?: React.ReactElement;
   /** Whether to hide the sign in button when logged in or not. Defaults to `true`. */
@@ -36,7 +36,6 @@ export interface SignInProps {
 
 export const SignIn = ({
   buttonProps = {},
-  clientId,
   component,
   hideWhenSignedIn = true,
   onError,
@@ -46,6 +45,7 @@ export const SignIn = ({
 }: SignInProps) => {
   const { data: user } = useUser();
   const [fetchingUser, setFetchingUser] = useState(false);
+  const { clientId } = useContext(FractalSDKContext);
   const { fetchAndSetUser } = useUserSetter();
 
   const doError = (e: FractalSDKError) => {

--- a/src/context/fractal-sdk-context.tsx
+++ b/src/context/fractal-sdk-context.tsx
@@ -2,7 +2,8 @@ import { clearIdAndTokenInLS } from 'core/token';
 import { createContext, useCallback, useState } from 'react';
 import { User, UserWallet } from 'types';
 
-interface UserContextState {
+interface FractalSDKContextState {
+  clientId: string;
   resetUser: () => void;
   setUser: (user: User | undefined) => void;
   setUserWallet: (userWallet: UserWallet | undefined) => void;
@@ -10,7 +11,8 @@ interface UserContextState {
   userWallet?: UserWallet;
 }
 
-export const UserContext = createContext<UserContextState>({
+export const FractalSDKContext = createContext<FractalSDKContextState>({
+  clientId: '',
   resetUser: () => undefined,
   setUser: () => undefined,
   setUserWallet: () => undefined,
@@ -18,11 +20,15 @@ export const UserContext = createContext<UserContextState>({
   userWallet: undefined,
 });
 
-export type UserContextProviderProps = React.PropsWithChildren<
-  Record<never, never>
->;
+export interface FractalSDKContextProviderProps
+  extends React.PropsWithChildren<Record<never, never>> {
+  clientId: string;
+}
 
-export function UserContextProvider({ children }: UserContextProviderProps) {
+export function FractalSDKContextProvider({
+  children,
+  clientId,
+}: FractalSDKContextProviderProps) {
   const [user, setUser] = useState<User | undefined>(undefined);
   const [userWallet, setUserWallet] = useState<UserWallet | undefined>(
     undefined,
@@ -34,8 +40,9 @@ export function UserContextProvider({ children }: UserContextProviderProps) {
   }, []);
 
   return (
-    <UserContext.Provider
+    <FractalSDKContext.Provider
       value={{
+        clientId,
         resetUser,
         setUser,
         setUserWallet,
@@ -44,6 +51,6 @@ export function UserContextProvider({ children }: UserContextProviderProps) {
       }}
     >
       {children}
-    </UserContext.Provider>
+    </FractalSDKContext.Provider>
   );
 }

--- a/src/hooks/public/use-coins.test.tsx
+++ b/src/hooks/public/use-coins.test.tsx
@@ -1,6 +1,6 @@
 import { FractalSdkWalletGetCoinsResponseCoin } from '@fractalwagmi/fractal-sdk-api';
 import { renderHook } from '@testing-library/react-hooks/dom';
-import { UserContextProvider } from 'context/user';
+import { FractalSDKContextProvider } from 'context/fractal-sdk-context';
 import { sdkApiClient } from 'core/api/client';
 import * as tokenModule from 'core/token';
 import { TEST_ACCESS_TOKEN, TEST_FRACTAL_USER } from 'hooks/__data__/constants';
@@ -53,7 +53,9 @@ describe('useCoins', () => {
 
     wrapper = ({ children }) => (
       <SWRConfig value={{ provider: () => new Map() }}>
-        <UserContextProvider>{children}</UserContextProvider>
+        <FractalSDKContextProvider clientId="abc">
+          {children}
+        </FractalSDKContextProvider>
       </SWRConfig>
     );
   });

--- a/src/hooks/public/use-items.test.tsx
+++ b/src/hooks/public/use-items.test.tsx
@@ -1,6 +1,6 @@
 import { FractalSdkWalletGetItemsResponseItem } from '@fractalwagmi/fractal-sdk-api';
 import { renderHook } from '@testing-library/react-hooks/dom';
-import { UserContextProvider } from 'context/user';
+import { FractalSDKContextProvider } from 'context/fractal-sdk-context';
 import { sdkApiClient } from 'core/api/client';
 import * as tokenModule from 'core/token';
 import { TEST_ACCESS_TOKEN, TEST_FRACTAL_USER } from 'hooks/__data__/constants';
@@ -63,7 +63,9 @@ describe('useItems', () => {
 
     wrapper = ({ children }) => (
       <SWRConfig value={{ provider: () => new Map() }}>
-        <UserContextProvider>{children}</UserContextProvider>
+        <FractalSDKContextProvider clientId="abc">
+          {children}
+        </FractalSDKContextProvider>
       </SWRConfig>
     );
   });

--- a/src/hooks/public/use-logout.ts
+++ b/src/hooks/public/use-logout.ts
@@ -1,8 +1,8 @@
-import { UserContext } from 'context/user';
+import { FractalSDKContext } from 'context/fractal-sdk-context';
 import { useContext } from 'react';
 
 export const useLogout = () => {
-  const { resetUser } = useContext(UserContext);
+  const { resetUser } = useContext(FractalSDKContext);
 
   return {
     logout: resetUser,

--- a/src/hooks/public/use-user-wallet.ts
+++ b/src/hooks/public/use-user-wallet.ts
@@ -1,4 +1,4 @@
-import { UserContext } from 'context/user';
+import { FractalSDKContext } from 'context/fractal-sdk-context';
 import { PublicHookResponse } from 'hooks/public/types';
 import { useContext } from 'react';
 import { UserWallet } from 'types';
@@ -7,6 +7,6 @@ export const useUserWallet = (): Omit<
   PublicHookResponse<UserWallet | undefined>,
   'error' | 'refetch'
 > => {
-  const { userWallet } = useContext(UserContext);
+  const { userWallet } = useContext(FractalSDKContext);
   return { data: userWallet };
 };

--- a/src/hooks/public/use-user.ts
+++ b/src/hooks/public/use-user.ts
@@ -1,4 +1,4 @@
-import { UserContext } from 'context/user';
+import { FractalSDKContext } from 'context/fractal-sdk-context';
 import { PublicHookResponse } from 'hooks/public/types';
 import { useContext } from 'react';
 import { User } from 'types';
@@ -7,6 +7,6 @@ export const useUser = (): Omit<
   PublicHookResponse<User | undefined>,
   'error' | 'refetch'
 > => {
-  const { user } = useContext(UserContext);
+  const { user } = useContext(FractalSDKContext);
   return { data: user };
 };

--- a/src/hooks/use-user-setter.test.tsx
+++ b/src/hooks/use-user-setter.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks/dom';
-import { UserContextProvider } from 'context/user';
+import { FractalSDKContextProvider } from 'context/fractal-sdk-context';
 import { sdkApiClient } from 'core/api/client';
 import { useUser } from 'hooks/public/use-user';
 import { useUserWallet } from 'hooks/public/use-user-wallet';
@@ -78,7 +78,9 @@ describe('useUserSetter', () => {
 
     it('sets a fractal user for the wrapping `UserContext`', async () => {
       const wrapper: React.FC = ({ children }) => (
-        <UserContextProvider>{children}</UserContextProvider>
+        <FractalSDKContextProvider clientId="abc">
+          {children}
+        </FractalSDKContextProvider>
       );
       const { result } = renderHook(
         () => {
@@ -110,7 +112,9 @@ describe('useUserSetter', () => {
 
     it('sets a fractal user wallet for the wrapping `UserContext`', async () => {
       const wrapper: React.FC = ({ children }) => (
-        <UserContextProvider>{children}</UserContextProvider>
+        <FractalSDKContextProvider clientId="abc">
+          {children}
+        </FractalSDKContextProvider>
       );
       const { result } = renderHook(
         () => {

--- a/src/hooks/use-user-setter.ts
+++ b/src/hooks/use-user-setter.ts
@@ -1,4 +1,4 @@
-import { UserContext } from 'context/user';
+import { FractalSDKContext } from 'context/fractal-sdk-context';
 import { sdkApiClient } from 'core/api/client';
 import { Endpoint } from 'core/api/endpoints';
 import { maybeIncludeAuthorizationHeaders } from 'core/api/headers';
@@ -7,7 +7,7 @@ import { useCallback, useContext } from 'react';
 import { UserWallet, BaseUser, User } from 'types';
 
 export const useUserSetter = () => {
-  const { setUser, setUserWallet } = useContext(UserContext);
+  const { setUser, setUserWallet } = useContext(FractalSDKContext);
 
   const fetchAndSetUser = useCallback(
     async (baseUser: BaseUser, accessToken: string) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { FractalSDKError } from 'core/error';
 
 export { SignIn as SignInWithFractal } from 'components/sign-in';
-export { UserContextProvider as FractalProvider } from 'context/user';
+export { FractalSDKContextProvider as FractalProvider } from 'context/fractal-sdk-context';
 export type { SignInProps } from 'components/sign-in';
 
 export { FractalSDKError } from 'core/error';


### PR DESCRIPTION
NOTE: This is a breaking change. (Leaving for posterity so we remember to bump the major version number on the next release.)

TODO: Update reference docs website accordingly.