### PR TITLE
[BREAKING CHANGE] Adds better sign out behavior for `SignInWithFractal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,37 +66,49 @@ export function YourSignInComponent() {
 By default, there are 2 button variants that we support:
 
 ```tsx
-// There is a "light" (default) and "dark" variant:
-<SignInWithFractal variant="dark">
+const YourComponent = () => {
+  // There is a "light" (default) and "dark" variant:
+  return <SignInWithFractal variant="dark">;
+}
 ```
 
 You can customize the look of the button with either of these options:
 
 ```tsx
-// Using your own class name to override any default styles:
-<SignInWithFractal className="foobar">
+const YourComponent = () => {
+  // Using your own class name to override any default styles:
+  return <SignInWithFractal className="foobar">;
+};
 ```
 
 ```tsx
-// Use your own child component:
-<SignInWithFractal component={<YourOwnButton />}>
+const YourComponent = () => {
+  // Use your own child component:
+  return <SignInWithFractal component={<YourOwnButton />}>;
+};
+
+// [CAVEAT] You'll need to make sure that `YourOwnButton` accepts an `onClick`
+// prop, otherwise our sign in logic will not run.
+const YourOwnButton = ({ onClick }: { onClick?: () => void }) => {
+  return <button onClick={onClick}>Your Own Button</button>;
+};
 ```
 
 #### SignInWithFractal Props
 
-| Prop               | Type / Description                                                                                                                   | Default            |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
-| `buttonProps`      | `HTMLAttributes<HTMLButtonElement>`<br/>Any additional props for `<button>` that should be passed to the default sign-in button.     | `{}`               |
-| `component`        | `React.ReactElement`<br/>Optional component to render instead of the default sign-in button                                          | `undefined`        |
-| `signOutComponent` | `React.ReactElement`<br/>Optional component to render instead of the default sign-out button                                         |
-| `undefined`        |
-| `hideWhenSignedIn` | `boolean`<br/>Whether to hide the sign out button when signed in or not.                                                             | `false`            |
-| `onError`          | `(e: FractalSDKError) => void`<br/>A callback function to call when an error occurs.                                                 | `undefined`        |
-| `onSuccess`        | `(user: User) => void`<br/>A callback function to call when a user successfully signs in.                                            | `undefined`        |
-| `onSignOut`        | `() => void`<br/>A callback function to call when a sign out occurs.                                                                 |
-| `undefined`        |
-| `scopes`           | `Scope[]`<br/>The scope to assign to the access token. See [src/types/scope.ts](/src/types/scope.ts) for a list of available scopes. | `[Scope.IDENTIFY]` |
-| `variant`          | `"light" \| "dark"`<br/>The button style variant to use.                                                                             | `"light"`          |
+| Prop                | Type / Description                                                                                                                   | Default            |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
+| `buttonProps`       | `HTMLAttributes<HTMLButtonElement>`<br/>Any additional props for `<button>` that should be passed to the default sign-in button.     | `{}`               |
+| `component`         | `React.ReactElement`<br/>Optional component to render instead of the default sign-in button                                          | `undefined`        |
+| `signOutComponent`  | `React.ReactElement`<br/>Optional component to render instead of the default sign-out button                                         |
+| `undefined`         |
+| `hideSignOutButton` | `boolean`<br/>Whether to hide the sign out button when signed in or not.                                                             | `false`            |
+| `onError`           | `(e: FractalSDKError) => void`<br/>A callback function to call when an error occurs.                                                 | `undefined`        |
+| `onSuccess`         | `(user: User) => void`<br/>A callback function to call when a user successfully signs in.                                            | `undefined`        |
+| `onSignOut`         | `() => void`<br/>A callback function to call when a sign out occurs.                                                                 |
+| `undefined`         |
+| `scopes`            | `Scope[]`<br/>The scope to assign to the access token. See [src/types/scope.ts](/src/types/scope.ts) for a list of available scopes. | `[Scope.IDENTIFY]` |
+| `variant`           | `"light" \| "dark"`<br/>The button style variant to use.                                                                             | `"light"`          |
 
 ### 4. Use the hooks to access data
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,13 @@ You can customize the look of the button with either of these options:
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
 | `buttonProps`      | `HTMLAttributes<HTMLButtonElement>`<br/>Any additional props for `<button>` that should be passed to the default sign-in button.     | `{}`               |
 | `component`        | `React.ReactElement`<br/>Optional component to render instead of the default sign-in button                                          | `undefined`        |
-| `hideWhenSignedIn` | `boolean`<br/>Whether to hide the sign in button when logged in or not.                                                              | `true`             |
+| `signOutComponent` | `React.ReactElement`<br/>Optional component to render instead of the default sign-out button                                         |
+| `undefined`        |
+| `hideWhenSignedIn` | `boolean`<br/>Whether to hide the sign out button when signed in or not.                                                             | `false`            |
 | `onError`          | `(e: FractalSDKError) => void`<br/>A callback function to call when an error occurs.                                                 | `undefined`        |
-| `onSuccess`        | `(user: User) => void`<br/>A callback function to call when a user successfully logs in.                                             | `undefined`        |
+| `onSuccess`        | `(user: User) => void`<br/>A callback function to call when a user successfully signs in.                                            | `undefined`        |
+| `onSignOut`        | `() => void`<br/>A callback function to call when a sign out occurs.                                                                 |
+| `undefined`        |
 | `scopes`           | `Scope[]`<br/>The scope to assign to the access token. See [src/types/scope.ts](/src/types/scope.ts) for a list of available scopes. | `[Scope.IDENTIFY]` |
 | `variant`          | `"light" \| "dark"`<br/>The button style variant to use.                                                                             | `"light"`          |
 
@@ -118,5 +122,19 @@ export function YourWalletComponent() {
   const { data: coins } = useCoins();
 
   return <div>...</div>;
+}
+```
+
+### 5. Other misc. Non-data related hooks:
+
+#### Logging out
+
+```tsx
+import { useSignOut } from '@fractalwagmi/fractal-sdk';
+
+export function YourWalletComponent() {
+  const { signOut } = useSignOut();
+
+  return <button onClick={signOut}>Your Sign Out Button Text</button>;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -100,13 +100,11 @@ const YourOwnButton = ({ onClick }: { onClick?: () => void }) => {
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
 | `buttonProps`       | `HTMLAttributes<HTMLButtonElement>`<br/>Any additional props for `<button>` that should be passed to the default sign-in button.     | `{}`               |
 | `component`         | `React.ReactElement`<br/>Optional component to render instead of the default sign-in button                                          | `undefined`        |
-| `signOutComponent`  | `React.ReactElement`<br/>Optional component to render instead of the default sign-out button                                         |
-| `undefined`         |
+| `signOutComponent`  | `React.ReactElement`<br/>Optional component to render instead of the default sign-out button                                         | `undefined`        |
 | `hideSignOutButton` | `boolean`<br/>Whether to hide the sign out button when signed in or not.                                                             | `false`            |
 | `onError`           | `(e: FractalSDKError) => void`<br/>A callback function to call when an error occurs.                                                 | `undefined`        |
 | `onSuccess`         | `(user: User) => void`<br/>A callback function to call when a user successfully signs in.                                            | `undefined`        |
-| `onSignOut`         | `() => void`<br/>A callback function to call when a sign out occurs.                                                                 |
-| `undefined`         |
+| `onSignOut`         | `() => void`<br/>A callback function to call when a sign out occurs.                                                                 | `undefined`        |
 | `scopes`            | `Scope[]`<br/>The scope to assign to the access token. See [src/types/scope.ts](/src/types/scope.ts) for a list of available scopes. | `[Scope.IDENTIFY]` |
 | `variant`           | `"light" \| "dark"`<br/>The button style variant to use.                                                                             | `"light"`          |
 

--- a/src/components/auth-button.tsx
+++ b/src/components/auth-button.tsx
@@ -1,48 +1,35 @@
 import { css, cx } from '@emotion/css';
 import { FractalFLogo } from 'components/fractal-f-logo';
+import { getDefaultButtonStyles } from 'components/styles';
 
-const DEFAULT_BUTTON_TEXT = 'Sign in with Fractal';
 const LOADING_TEXT = 'Loading...';
 
-export interface SignInButtonProps
+export interface AuthButtonProps
   extends React.ComponentPropsWithoutRef<'button'> {
+  buttonText: string;
   loading?: boolean;
   variant?: 'light' | 'dark';
 }
 
-export const SignInButton = ({
+export const AuthButton = ({
+  buttonText,
   loading = false,
   variant,
   ...buttonProps
-}: SignInButtonProps) => {
+}: AuthButtonProps) => {
   const {
     buttonBackground,
-    buttonBackgroundHover,
+    buttonBackgroundOnHover,
     logoBackground,
     logoFill,
     textColor,
   } = getColorsFromVariant(variant);
 
-  const defaultButtonStyles = css(`
-  align-items: center;
-  background: ${buttonBackground};
-  border-radius: 0.25rem;
-  border: 0;
-  color: ${textColor};
-  cursor: pointer;
-  display: flex;
-  font-family: "Quattrocento Sans", sans-serif;
-  font-size: 0.875rem;
-  font-weight: 700;
-  letter-spacing: 0.02857em;
-  padding: 0.1875rem;
-  text-transform: uppercase;
-  width: max-content;
-
-  &:hover {
-    background: ${buttonBackgroundHover};
-  }
-`);
+  const defaultButtonStyles = getDefaultButtonStyles({
+    buttonBackground,
+    buttonBackgroundOnHover,
+    textColor,
+  });
 
   return (
     <button
@@ -71,18 +58,18 @@ export const SignInButton = ({
           white-space: nowrap;
         `}
       >
-        {loading ? LOADING_TEXT : DEFAULT_BUTTON_TEXT}
+        {loading ? LOADING_TEXT : buttonText}
       </div>
     </button>
   );
 };
 
-function getColorsFromVariant(variant: SignInButtonProps['variant'] = 'dark') {
+function getColorsFromVariant(variant: AuthButtonProps['variant'] = 'dark') {
   switch (variant) {
     case 'light':
       return {
         buttonBackground: '#c31a88',
-        buttonBackgroundHover: '#d71d96',
+        buttonBackgroundOnHover: '#d71d96',
         logoBackground: '#f2059f',
         logoFill: '#fff',
         textColor: '#fff',
@@ -90,7 +77,7 @@ function getColorsFromVariant(variant: SignInButtonProps['variant'] = 'dark') {
     case 'dark':
       return {
         buttonBackground: '#000',
-        buttonBackgroundHover: '#181818',
+        buttonBackgroundOnHover: '#181818',
         logoBackground: '#232323',
         logoFill: '#f2059f',
         textColor: '#fff',

--- a/src/components/sign-in.tsx
+++ b/src/components/sign-in.tsx
@@ -11,7 +11,14 @@ import { Scope, User } from 'types';
 const DEFAULT_SIGN_IN_BUTTON_TEXT = 'Sign in with Fractal';
 const DEFAULT_SIGN_OUT_BUTTON_TEXT = 'Sign out';
 
-export interface SignInProps {
+interface PropsWithOnClick {
+  onClick: () => void;
+}
+
+export interface SignInProps<
+  ComponentProps extends PropsWithOnClick = PropsWithOnClick,
+  SignOutComponentProps extends PropsWithOnClick = PropsWithOnClick,
+> {
   /**
    * Any additional props for <button> that should be passed to the default
    * sign-in button.
@@ -23,13 +30,13 @@ export interface SignInProps {
    * `signOutComponent` to control what the button looks like for the purposes
    * of signing out.
    */
-  component?: React.ReactElement;
+  component?: React.ReactElement<ComponentProps>;
   /**
    * Whether to hide the button completely when signed in or not.
    *
    * Defaults to `false`.
    */
-  hideWhenSignedIn?: boolean;
+  hideSignOutButton?: boolean;
   onError?: (e: FractalSDKError) => void;
   onSignOut?: () => void;
   onSuccess?: (user: User) => void;
@@ -40,7 +47,7 @@ export interface SignInProps {
    */
   scopes?: Scope[];
   /** Optional component to render instead of the default sign-out button. */
-  signOutComponent?: React.ReactElement;
+  signOutComponent?: React.ReactElement<SignOutComponentProps>;
   /**
    * The button style variant to use.
    *
@@ -53,7 +60,7 @@ export const SignIn = ({
   buttonProps = {},
   component,
   signOutComponent,
-  hideWhenSignedIn = false,
+  hideSignOutButton = false,
   onError,
   onSuccess,
   onSignOut,
@@ -122,7 +129,7 @@ export const SignIn = ({
     refreshUser();
   }, [user, fetchingUser]);
 
-  if (signedIn && hideWhenSignedIn) {
+  if (signedIn && hideSignOutButton) {
     return null;
   }
 
@@ -141,7 +148,9 @@ export const SignIn = ({
   // but THEIR sign in component when signed out.
   if (component) {
     return React.cloneElement(component, {
-      onClick: signIn,
+      onClick: () => {
+        signIn();
+      },
     });
   }
 

--- a/src/components/sign-in.tsx
+++ b/src/components/sign-in.tsx
@@ -1,12 +1,15 @@
-import { SignInButton, SignInButtonProps } from 'components/sign-in-button';
+import { AuthButton, AuthButtonProps } from 'components/auth-button';
 import { FractalSDKContext } from 'context/fractal-sdk-context';
 import { FractalSDKError } from 'core/error';
 import { maybeGetAccessToken, maybeGetBaseUser } from 'core/token';
-import { useUser, useUserSetter } from 'hooks';
+import { useSignOut, useUser, useUserSetter } from 'hooks';
 import { useAuthUrl } from 'hooks/use-auth-url';
 import { useSignIn } from 'hooks/use-sign-in';
 import React, { HTMLAttributes, useContext, useEffect, useState } from 'react';
 import { Scope, User } from 'types';
+
+const DEFAULT_SIGN_IN_BUTTON_TEXT = 'Sign in with Fractal';
+const DEFAULT_SIGN_OUT_BUTTON_TEXT = 'Sign out';
 
 export interface SignInProps {
   /**
@@ -14,11 +17,21 @@ export interface SignInProps {
    * sign-in button.
    */
   buttonProps?: HTMLAttributes<HTMLButtonElement>;
-  /** Optional component to render instead of the default sign-in button. */
+  /**
+   * Optional component to render instead of the default sign-in button. If
+   * defining this prop, it's recommended that you also define
+   * `signOutComponent` to control what the button looks like for the purposes
+   * of signing out.
+   */
   component?: React.ReactElement;
-  /** Whether to hide the sign in button when logged in or not. Defaults to `true`. */
+  /**
+   * Whether to hide the button completely when signed in or not.
+   *
+   * Defaults to `false`.
+   */
   hideWhenSignedIn?: boolean;
   onError?: (e: FractalSDKError) => void;
+  onSignOut?: () => void;
   onSuccess?: (user: User) => void;
   /**
    * The scopes to assign to the access token. Defaults to [Scope.IDENTIFY].
@@ -26,27 +39,39 @@ export interface SignInProps {
    * See src/types/scope.ts for a list of available scopes.
    */
   scopes?: Scope[];
+  /** Optional component to render instead of the default sign-out button. */
+  signOutComponent?: React.ReactElement;
   /**
    * The button style variant to use.
    *
    * Possible values: 'light' | 'dark'. Defaults to 'light'.
    */
-  variant?: SignInButtonProps['variant'];
+  variant?: AuthButtonProps['variant'];
 }
 
 export const SignIn = ({
   buttonProps = {},
   component,
-  hideWhenSignedIn = true,
+  signOutComponent,
+  hideWhenSignedIn = false,
   onError,
   onSuccess,
+  onSignOut,
   scopes,
   variant = 'light',
 }: SignInProps) => {
+  const { onResetUser } = useContext(FractalSDKContext);
   const { data: user } = useUser();
+  const { signOut } = useSignOut();
   const [fetchingUser, setFetchingUser] = useState(false);
   const { clientId } = useContext(FractalSDKContext);
   const { fetchAndSetUser } = useUserSetter();
+
+  if (onSignOut) {
+    onResetUser(onSignOut);
+  }
+
+  const signedIn = Boolean(user);
 
   const doError = (e: FractalSDKError) => {
     if (!onError) {
@@ -97,10 +122,23 @@ export const SignIn = ({
     refreshUser();
   }, [user, fetchingUser]);
 
-  if (user && hideWhenSignedIn) {
+  if (signedIn && hideWhenSignedIn) {
     return null;
   }
 
+  if (signedIn && signOutComponent) {
+    return React.cloneElement(signOutComponent, {
+      onClick: signOut,
+    });
+  }
+
+  // We explicitly don't do a `!signedIn && component` check here because we
+  // want to guarantee that if a caller provides a `component`, it will always
+  // be rendered even when they are logged in and aren't passing in a
+  // `signOutComponent`.
+  //
+  // This prevents accidentally showing OUR sign out component when signed in
+  // but THEIR sign in component when signed out.
   if (component) {
     return React.cloneElement(component, {
       onClick: signIn,
@@ -108,9 +146,12 @@ export const SignIn = ({
   }
 
   return (
-    <SignInButton
+    <AuthButton
       variant={variant}
-      onClick={signIn}
+      onClick={signedIn ? signOut : signIn}
+      buttonText={
+        signedIn ? DEFAULT_SIGN_OUT_BUTTON_TEXT : DEFAULT_SIGN_IN_BUTTON_TEXT
+      }
       {...buttonProps}
       loading={fetchingUser}
     />

--- a/src/components/styles.ts
+++ b/src/components/styles.ts
@@ -1,0 +1,34 @@
+import { css } from '@emotion/css';
+import * as CSS from 'csstype';
+
+interface Parameters {
+  buttonBackground: CSS.Property.BackgroundColor;
+  buttonBackgroundOnHover: CSS.Property.BackgroundColor;
+  textColor: CSS.Property.Color;
+}
+
+export const getDefaultButtonStyles = ({
+  buttonBackground,
+  buttonBackgroundOnHover,
+  textColor,
+}: Parameters) =>
+  css(`
+    align-items: center;
+    background: ${buttonBackground};
+    border-radius: 0.25rem;
+    border: 0;
+    color: ${textColor};
+    cursor: pointer;
+    display: flex;
+    font-family: "Quattrocento Sans", sans-serif;
+    font-size: 0.875rem;
+    font-weight: 700;
+    letter-spacing: 0.02857em;
+    padding: 0.1875rem;
+    text-transform: uppercase;
+    width: max-content;
+
+    &:hover {
+      background: ${buttonBackgroundOnHover};
+    }
+  `);

--- a/src/context/fractal-sdk-context.tsx
+++ b/src/context/fractal-sdk-context.tsx
@@ -4,6 +4,7 @@ import { User, UserWallet } from 'types';
 
 interface FractalSDKContextState {
   clientId: string;
+  onResetUser: (resetHandler: () => void) => void;
   resetUser: () => void;
   setUser: (user: User | undefined) => void;
   setUserWallet: (userWallet: UserWallet | undefined) => void;
@@ -13,6 +14,7 @@ interface FractalSDKContextState {
 
 export const FractalSDKContext = createContext<FractalSDKContextState>({
   clientId: '',
+  onResetUser: () => undefined,
   resetUser: () => undefined,
   setUser: () => undefined,
   setUserWallet: () => undefined,
@@ -33,16 +35,27 @@ export function FractalSDKContextProvider({
   const [userWallet, setUserWallet] = useState<UserWallet | undefined>(
     undefined,
   );
+  const [resetHandlers, setResetHandlers] = useState<Set<() => void>>(
+    () => new Set(),
+  );
   const resetUser = useCallback(() => {
     clearIdAndTokenInLS();
     setUser(undefined);
     setUserWallet(undefined);
+    for (const handler of resetHandlers) {
+      handler();
+    }
+  }, [resetHandlers]);
+
+  const onResetUser = useCallback((handleOnResetUser: () => void) => {
+    setResetHandlers(handlers => new Set([...handlers]).add(handleOnResetUser));
   }, []);
 
   return (
     <FractalSDKContext.Provider
       value={{
         clientId,
+        onResetUser,
         resetUser,
         setUser,
         setUserWallet,

--- a/src/hooks/public/index.ts
+++ b/src/hooks/public/index.ts
@@ -2,5 +2,6 @@ export * from 'hooks/public/use-coins';
 export * from 'hooks/public/use-items';
 export * from 'hooks/public/use-user-wallet';
 export * from 'hooks/public/use-user';
-export * from 'hooks/public/use-logout';
+export * from 'hooks/public/use-sign-out';
 export * from 'hooks/public/use-sign-transaction';
+export * from 'hooks/public/use-sign-out';

--- a/src/hooks/public/use-sign-out.ts
+++ b/src/hooks/public/use-sign-out.ts
@@ -1,10 +1,10 @@
 import { FractalSDKContext } from 'context/fractal-sdk-context';
 import { useContext } from 'react';
 
-export const useLogout = () => {
+export const useSignOut = () => {
   const { resetUser } = useContext(FractalSDKContext);
 
   return {
-    logout: resetUser,
+    signOut: resetUser,
   };
 };

--- a/src/hooks/use-auth-url.ts
+++ b/src/hooks/use-auth-url.ts
@@ -49,7 +49,12 @@ export const useAuthUrl = ({
       }
     };
     getUrl();
-  }, [user]);
+  }, [
+    // Making this effect depend on `user` ensures we re-fetch for the approval
+    // url when a user object is mutated (signed out and sign back in, for
+    // example).
+    user,
+  ]);
 
   return {
     code,

--- a/src/hooks/use-auth-url.ts
+++ b/src/hooks/use-auth-url.ts
@@ -1,7 +1,8 @@
+import { FractalSDKContext } from 'context/fractal-sdk-context';
 import { authPrivateWebSdkApiClient } from 'core/api/client';
 import { FractalSDKError } from 'core/error';
 import { verifyScopes } from 'core/scope';
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { Scope } from 'types';
 
 const DEFAULT_SCOPE = [Scope.IDENTIFY];
@@ -17,6 +18,7 @@ export const useAuthUrl = ({
   onError,
   scopes = DEFAULT_SCOPE,
 }: UseAuthUrlParameters) => {
+  const { user } = useContext(FractalSDKContext);
   const [url, setUrl] = useState<string | undefined>();
   const [code, setCode] = useState<string | undefined>();
 
@@ -47,7 +49,7 @@ export const useAuthUrl = ({
       }
     };
     getUrl();
-  }, []);
+  }, [user]);
 
   return {
     code,

--- a/src/hooks/use-popup-connection.ts
+++ b/src/hooks/use-popup-connection.ts
@@ -89,6 +89,7 @@ export const usePopupConnection = () => {
     }
     popupWindow.close();
     setHandlers(new Map());
+    setConnection(undefined);
   }, [popupWindow, setHandlers]);
 
   const handleMessage = useCallback(


### PR DESCRIPTION
Most notably, this PR introduces a change to the public interface that I think we should ship before we do our launch.

A caller will now be able to specify both `component` and `signOutComponent` to control the rendering of signed in/out states.

As a result, I've renamed `hideWhenSignedIn` to `hideSignOutButton` for clarity and updated the docs accordingly.

Loom explaining everything in detail:

https://www.loom.com/share/88155ea96ded4eb4ba2489f212a90563