### PR TITLE
Prevents multiple popups from opening.

### DIFF
--- a/src/hooks/public/use-coins.ts
+++ b/src/hooks/public/use-coins.ts
@@ -6,6 +6,7 @@ import { FractalSDKError } from 'core/error';
 import { maybeGetAccessToken } from 'core/token';
 import { PublicDataHookResponse } from 'hooks/public/types';
 import { useUser } from 'hooks/public/use-user';
+import { createCacheToken } from 'lib/util/cache-token';
 import { useCallback, useMemo, useState } from 'react';
 import useSWR from 'swr';
 import { Coin } from 'types';
@@ -13,17 +14,17 @@ import { Coin } from 'types';
 export const useCoins = (): PublicDataHookResponse<Coin[]> => {
   const { data: user } = useUser();
   const accessToken = maybeGetAccessToken();
-  const [fetchToken, setFetchToken] = useState(0);
+  const [cacheToken, setCacheToken] = useState(createCacheToken());
 
   const refetch = useCallback(() => {
-    setFetchToken(fetchToken + 1);
-  }, [fetchToken]);
+    setCacheToken(createCacheToken());
+  }, []);
 
-  const requestKey = user
-    ? [Endpoint.GET_COINS, user.userId, fetchToken]
+  const getCoinsRequestCacheKey = user
+    ? [Endpoint.GET_COINS, user.userId, cacheToken]
     : null;
   const { data, error: errorResponse } = useSWR(
-    requestKey,
+    getCoinsRequestCacheKey,
     async () =>
       (
         await sdkApiClient.v1.getCoins({

--- a/src/hooks/public/use-items.ts
+++ b/src/hooks/public/use-items.ts
@@ -6,6 +6,7 @@ import { FractalSDKError } from 'core/error';
 import { maybeGetAccessToken } from 'core/token';
 import { PublicDataHookResponse } from 'hooks/public/types';
 import { useUser } from 'hooks/public/use-user';
+import { createCacheToken } from 'lib/util/cache-token';
 import { useCallback, useMemo, useState } from 'react';
 import useSWR from 'swr';
 import { Item } from 'types';
@@ -13,18 +14,18 @@ import { Item } from 'types';
 export const useItems = (): PublicDataHookResponse<Item[]> => {
   const { data: user } = useUser();
   const accessToken = maybeGetAccessToken();
-  const [fetchToken, setFetchToken] = useState(0);
+  const [cacheToken, setCacheToken] = useState(createCacheToken());
 
   const refetch = useCallback(() => {
-    setFetchToken(fetchToken + 1);
-  }, [fetchToken]);
+    setCacheToken(createCacheToken());
+  }, []);
 
-  const requestKey = user
-    ? [Endpoint.GET_WALLET_ITEMS, user.userId, fetchToken]
+  const getWalletItemsCacheKey = user
+    ? [Endpoint.GET_WALLET_ITEMS, user.userId, cacheToken]
     : null;
 
   const { data, error: responseError } = useSWR(
-    requestKey,
+    getWalletItemsCacheKey,
     async () =>
       (
         await sdkApiClient.v1.getWalletItems({

--- a/src/lib/util/cache-token.ts
+++ b/src/lib/util/cache-token.ts
@@ -1,0 +1,9 @@
+/** Creates a random string. Useful for using as a cache token. */
+export function createCacheToken() {
+  return random11CharString() + random11CharString();
+}
+
+function random11CharString() {
+  // See https://stackoverflow.com/questions/10726909/random-alpha-numeric-string-in-javascript for details.
+  return Math.random().toString(36).slice(2);
+}


### PR DESCRIPTION
This fix enforces `useSWR` to stop sending a URL fetch for the same transaction b58 string by default.

This means we have to offer an affordance for the caller to be able to refetch programmatically, so I added a
new `refetch` exported function (similar to the other data hooks.)