### PR TITLE
Fix Sign Transaction to return a fn instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,10 +219,7 @@ unsigned transaction and initialize an approval popup flow for the user to
 approve the transaction:
 
 ```tsx
-import {
-  useSignTransaction,
-  FractalSDKSignTransactionDeniedError,
-} from '@fractalwagmi/fractal-sdk';
+import { useSignTransaction } from '@fractalwagmi/fractal-sdk';
 
 interface YourComponentProps {
   someTransactionB58: string | undefined;
@@ -230,41 +227,27 @@ interface YourComponentProps {
 
 export function YourComponent({ someTransactionB58 }: YourComponentProps) {
   const {
-    // `data` is the transaction signature. This is populated when the user
-    // approves the transaction.
-    data: signature,
-
-    // Indicates whether the popup is currently open and the user is approving
-    // the transaction.
-    approving,
-
-    // A function to call to initiate another approve transaction popup. This
-    // only needs to be called if you want to re-initiate another popup for
-    // the same `unsignedTransactionB58` input. See memo below.
-    refetch,
-
-    // See "error handling" section below.
-    error,
-  } = useSignTransaction({
-    // Given the same `unsignedTransactionB58` input, the popup will only be
-    // opened once.
-    //
-    // If a user denies approval for a transaction and you need to re-request
-    // their approval, you can call the `refetch` function that is returned by
-    // the hook.
-    unsignedTransactionB58: someTransactionB58,
-  });
-
-  const denied = e instanceof FractalSDKSignTransactionDeniedError;
+    // An async function to run which request's user approval to sign a
+    // transaction.
+    signTransaction,
+  } = useSignTransaction();
 
   return (
     <div>
-      <p>Transaction Signature: {signature}</p>
-      <p>An error occurred: {error.getUserFacingErrorMessage()}</p>
-      <p>Approval popup is currently {approving ? 'open' : 'closed'}</p>
-      {denied ? (
-        <button onClick={refetch}>Re-request an approval</button>
-      ) : null}
+      <button
+        onClick={async () => {
+          try {
+            const { signature } = await signTransaction(someTransactionB58);
+            // This is the transaction signature for the signed transaction.
+            console.log('signature = ', signature);
+          } catch (err: unknown) {
+            // See memo below on error handling.
+            console.log('err = ', err);
+          }
+        }}
+      >
+        Request user approval for transaction
+      </button>
     </div>
   );
 }
@@ -279,8 +262,8 @@ to accomplish this.
 
 #### Error handling for `useSignTransaction`
 
-The hook returns an `error` property that is `undefined` until an error occurs.
-The possible errors are:
+The `signTransaction` function returned by `useSignTransaction` will potentially
+throw the following error classes:
 
 | Error class                             | Meaning                                                                                                                                                   |
 | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/hooks/public/use-sign-transaction.tsx
+++ b/src/hooks/public/use-sign-transaction.tsx
@@ -1,8 +1,8 @@
-import { FractalWebsdkApprovalAuthorizeTransactionResponse } from '@fractalwagmi/fractal-sdk-websdk-api';
 import { FractalSDKContext } from 'context/fractal-sdk-context';
 import { webSdkApiClient } from 'core/api/client';
 import { Endpoint } from 'core/api/endpoints';
 import { maybeIncludeAuthorizationHeaders } from 'core/api/headers';
+import { FractalSDKError } from 'core/error';
 import { FractalSDKApprovalOccurringError } from 'core/error/approve';
 import { FractalSDKAuthenticationError } from 'core/error/auth';
 import {
@@ -14,10 +14,8 @@ import { Events } from 'core/messaging';
 import { POPUP_HEIGHT_PX } from 'core/popup';
 import { maybeGetAccessToken } from 'core/token';
 import { usePopupConnection } from 'hooks/use-popup-connection';
-import { createCacheToken } from 'lib/util/cache-token';
 import { assertObject } from 'lib/util/guards';
-import { useCallback, useContext, useEffect, useState } from 'react';
-import useSWRImmutable from 'swr/immutable';
+import { useCallback, useContext, useEffect, useRef } from 'react';
 
 const MIN_POPUP_HEIGHT_PX = POPUP_HEIGHT_PX;
 const MAX_POPUP_WIDTH_PX = 850;
@@ -29,108 +27,62 @@ type SignTransactionErrors =
   | FractalSDKSignTransactionDeniedError
   | FractalSDKSignTransactionUnknownError;
 
-interface UseSignTransactionParameters {
-  /** The unsigned transaction as a base-58 string. */
-  unsignedTransactionB58: string | undefined;
-}
+export const useSignTransaction = () => {
+  const { clientId } = useContext(FractalSDKContext);
+  const promiseResolversRef = useRef<{
+    reject: (err: SignTransactionErrors) => void;
+    resolve: (value: { signature: string }) => void;
+  } | null>(null);
 
-interface UseSignTransactionHookReturn {
-  approving: boolean;
-  /** The transaction signature. */
-  data: string | undefined;
-  error: SignTransactionErrors | undefined;
-  /**
-   * A function to call to re-initiate the approval request for a given unsigned
-   * transaction.
-   *
-   * This is useful if a user denies a particular transaction, but you want to
-   * manually re-initiate the approval request again for the same unsigned transaction.
-   *
-   * An approval will not be sent multiple times for the same
-   * `unsignedTransactionB58` input by default (unless the page refreshes.)
-   */
-  refetch: () => void;
-}
-
-export const useSignTransaction = ({
-  unsignedTransactionB58,
-}: UseSignTransactionParameters): UseSignTransactionHookReturn => {
-  const maybeInitiateRequest =
-    unsignedTransactionB58 !== undefined &&
-    unsignedTransactionB58.trim() !== '';
-
-  const [cacheToken, setCacheToken] = useState(createCacheToken());
-  const [signature, setSignature] = useState<string | undefined>(undefined);
-  const [signTransactionError, setSignTransactionError] = useState<
-    SignTransactionErrors | undefined
-  >(undefined);
   const { close, connection, open } = usePopupConnection({
-    enabled: maybeInitiateRequest,
     heightPx: Math.max(
       MIN_POPUP_HEIGHT_PX,
       Math.floor(window.innerHeight * 0.8),
     ),
     widthPx: Math.min(MAX_POPUP_WIDTH_PX, Math.floor(window.innerWidth * 0.8)),
   });
-  const { clientId } = useContext(FractalSDKContext);
 
-  useEffect(() => {
-    setSignTransactionError(undefined);
-  }, [unsignedTransactionB58]);
+  const fetchAuthorizeUrl = useCallback(
+    async (unsignedTransactionB58: string) => {
+      if (connection) {
+        throw new FractalSDKApprovalOccurringError(
+          `An approval flow for a previous transaction is already occurring`,
+        );
+      }
+      const accessToken = maybeGetAccessToken();
+      if (!accessToken) {
+        throw new FractalSDKAuthenticationError(
+          'Invalid or missing authentication token',
+        );
+      }
+      try {
+        const response = await webSdkApiClient.websdk.authorize(
+          {
+            clientId,
+            unsigned: unsignedTransactionB58,
+          },
+          {
+            headers: maybeIncludeAuthorizationHeaders(
+              accessToken,
+              Endpoint.AUTHORIZE_TRANSACTION,
+            ),
+          },
+        );
 
-  const authorizeCacheKey = maybeInitiateRequest
-    ? [
-        Endpoint.AUTHORIZE_TRANSACTION,
-        unsignedTransactionB58,
-        clientId,
-        cacheToken,
-      ]
-    : null;
-  // Using` useSWRImmutable` sets the revalidation booleans to `false`. This
-  // ensures we don't fetch a URL for a given unsignedTransaction that has
-  // already been requested. We invert control back to the caller to manually
-  // re-attempt if needed by using the `rerequest` function.
-  const { data, error: authorizeRequestError } = useSWRImmutable<
-    FractalWebsdkApprovalAuthorizeTransactionResponse,
-    SignTransactionErrors
-  >(authorizeCacheKey, async () => {
-    if (connection) {
-      throw new FractalSDKApprovalOccurringError(
-        `An approval flow for a previous transaction is already occurring`,
-      );
-    }
-    const accessToken = maybeGetAccessToken();
-    if (!accessToken) {
-      throw new FractalSDKAuthenticationError(
-        'Invalid or missing authentication token',
-      );
-    }
-    try {
-      const response = await webSdkApiClient.websdk.authorize(
-        {
-          clientId,
-          unsigned: unsignedTransactionB58,
-        },
-        {
-          headers: maybeIncludeAuthorizationHeaders(
-            accessToken,
-            Endpoint.AUTHORIZE_TRANSACTION,
-          ),
-        },
-      );
-
-      return response.data;
-    } catch (err: unknown) {
-      throw new FractalSDKInvalidTransactionError(
-        `Unable to initiate sign transaction flow. ${err}`,
-      );
-    }
-  });
+        return response.data;
+      } catch (err: unknown) {
+        throw new FractalSDKInvalidTransactionError(
+          `Unable to initiate sign transaction flow. ${err}`,
+        );
+      }
+    },
+    [connection],
+  );
 
   const handleSignedTransaction = useCallback(
     (payload: unknown) => {
       if (!assertPayloadHasSignature(payload)) {
-        setSignTransactionError(
+        promiseResolversRef.current?.reject(
           new FractalSDKSignTransactionUnknownError(
             `Received malformed payload from popup. payload = ${payload}`,
           ),
@@ -138,68 +90,73 @@ export const useSignTransaction = ({
         return;
       }
       close();
-      setSignature(payload.signature);
+      promiseResolversRef.current?.resolve({ signature: payload.signature });
+      promiseResolversRef.current = null;
     },
     [close],
   );
 
   const handleSignedTransactionDenied = useCallback(() => {
-    setSignTransactionError(
+    promiseResolversRef.current?.reject(
       new FractalSDKSignTransactionDeniedError('Transaction was denied'),
     );
+    promiseResolversRef.current = null;
     close();
   }, [close]);
 
   const handleSignedTransactionFailed = useCallback(() => {
-    setSignTransactionError(
+    promiseResolversRef.current?.reject(
       new FractalSDKSignTransactionUnknownError('An unknown error occurred.'),
     );
-  }, [close]);
+    promiseResolversRef.current = null;
+  }, []);
 
   useEffect(() => {
     if (!connection) {
       return;
     }
-
-    if (maybeInitiateRequest) {
-      connection.on(Events.SIGNED_TRANSACTION, handleSignedTransaction);
-      connection.on(Events.TRANSACTION_DENIED, handleSignedTransactionDenied);
-      connection.on(Events.POPUP_CLOSED, handleSignedTransactionDenied);
-      connection.on(
-        Events.FAILED_TO_SIGN_TRANSACTION,
-        handleSignedTransactionFailed,
-      );
-    } else {
-      connection.off(Events.SIGNED_TRANSACTION, handleSignedTransaction);
-      connection.off(Events.TRANSACTION_DENIED, handleSignedTransactionDenied);
-      connection.off(Events.POPUP_CLOSED, handleSignedTransactionDenied);
-      connection.off(
-        Events.FAILED_TO_SIGN_TRANSACTION,
-        handleSignedTransactionFailed,
-      );
-    }
+    connection.on(Events.SIGNED_TRANSACTION, handleSignedTransaction);
+    connection.on(Events.TRANSACTION_DENIED, handleSignedTransactionDenied);
+    connection.on(Events.POPUP_CLOSED, handleSignedTransactionDenied);
+    connection.on(
+      Events.FAILED_TO_SIGN_TRANSACTION,
+      handleSignedTransactionFailed,
+    );
   }, [
-    maybeInitiateRequest,
     connection,
+    handleSignedTransactionDenied,
     handleSignedTransaction,
     handleSignedTransactionFailed,
   ]);
 
-  useEffect(() => {
-    if (data?.url) {
-      open(data.url);
-    }
-  }, [data?.url]);
+  const signTransaction = useCallback(
+    async (unsignedTransactionB58: string) => {
+      (async () => {
+        try {
+          const { url } = await fetchAuthorizeUrl(unsignedTransactionB58);
+          open(url);
+        } catch (err: unknown) {
+          if (err instanceof FractalSDKError) {
+            throw err;
+          }
+          throw new FractalSDKSignTransactionUnknownError(
+            `An unknown error occurred trying to sign the transaction. err = ${err}`,
+          );
+        }
+      })();
 
-  const refetch = useCallback(() => {
-    setCacheToken(createCacheToken());
-  }, []);
+      return new Promise<{ signature: string }>((resolve, reject) => {
+        promiseResolversRef.current = {
+          reject,
+          resolve,
+        };
+      });
+    },
+    [fetchAuthorizeUrl],
+  );
 
   return {
-    approving: Boolean(connection),
-    data: signature,
-    error: authorizeRequestError ?? signTransactionError,
-    refetch,
+    signTransaction,
   };
 };
 


### PR DESCRIPTION
This basically goes back to the old way that I was doing it, it's a lot more sane to consume this bc transaction signing will occur often as a result of some arbitrary event happening, like a user clicking on something or a network response coming back on the game side, as opposed to specifically when a component renders (which is when hooks are able to detect changes.)

By returning a function, we can allow the caller to decide when to run this logic, instead of trying to shoe horn the react hook way of doing things which is completely coupled to the component lifecycle. This is not appropriate in some cases as no component may be rendering / re-rendering when the game wants to initiate a request to sign a transaction.

I didn't get to using react-query as part of this launch, but the plan is to include the usage of `useMutation` instead of `useQuery` to accomplish this.